### PR TITLE
cmd/korrel8: skip rule files other than YAML and JSON

### DIFF
--- a/cmd/korrel8/cmd/common.go
+++ b/cmd/korrel8/cmd/common.go
@@ -70,17 +70,34 @@ func newEngine() *engine.Engine {
 	e.AddDomain(alert.Domain, needStore(alert.OpenshiftManagerStore(cfg)))
 	e.AddDomain(loki.Domain, loki.NewStore(*lokiBaseURL, http.DefaultClient))
 
-	// Load rules
+	// Load rules.
 	for _, root := range *rulePaths {
 		check(filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-			check(err)
-			if d.Type().IsRegular() {
-				f := must(os.Open(path))
-				check(templaterule.Read(f, e))
+			if err != nil {
+				return err
 			}
+
+			if !d.Type().IsRegular() {
+				return nil
+			}
+
+			if filepath.Ext(path) != ".yml" && filepath.Ext(path) != ".yaml" && filepath.Ext(path) != ".json" {
+				return nil
+			}
+
+			f, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+
+			if err := templaterule.Read(f, e); err != nil {
+				return fmt.Errorf("%s: %w", path, err)
+			}
+
 			return nil
 		}))
 	}
+
 	return e
 }
 


### PR DESCRIPTION
This change discards rule files which don't have the '.yaml', '.yml' or '.json' extension. It avoids returning an error when a rule directory contains a Vim swap file for instance.

Signed-off-by: Simon Pasquier <spasquie@redhat.com>